### PR TITLE
Fix unit tests by chasing Drupal Core and Plugin

### DIFF
--- a/modules/payment_form/src/Entity/Payment/PaymentForm.php
+++ b/modules/payment_form/src/Entity/Payment/PaymentForm.php
@@ -16,7 +16,7 @@ use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\payment\Plugin\Payment\Method\PaymentExecutionPaymentMethodManager;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
 use Drupal\plugin\PluginDiscovery\LimitedPluginDiscoveryDecorator;
-use Drupal\plugin\PluginTypeInterface;
+use Drupal\plugin\PluginType\PluginTypeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -34,7 +34,7 @@ class PaymentForm extends ContentEntityForm {
   /**
    * The payment method plugin type.
    *
-   * @var \Drupal\plugin\PluginTypeInterface
+   * @var \Drupal\plugin\PluginType\PluginTypeInterface
    */
   protected $paymentMethodType;
 
@@ -53,7 +53,7 @@ class PaymentForm extends ContentEntityForm {
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    * @param \Drupal\Core\Session\AccountInterface $current_user
    * @param \Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface $plugin_selector_manager
-   * @param \Drupal\plugin\PluginTypeInterface $payment_method_type
+   * @param \Drupal\plugin\PluginType\PluginTypeInterface $payment_method_type
    */
   public function __construct(EntityManagerInterface $entity_manager, TranslationInterface $string_translation, AccountInterface $current_user, PluginSelectorManagerInterface $plugin_selector_manager, PluginTypeInterface $payment_method_type) {
     parent::__construct($entity_manager);
@@ -68,7 +68,7 @@ class PaymentForm extends ContentEntityForm {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    /** @var \Drupal\plugin\PluginTypeManagerInterface $plugin_type_manager */
+    /** @var \Drupal\plugin\PluginType\PluginTypeManagerInterface $plugin_type_manager */
     $plugin_type_manager = $container->get('plugin.plugin_type_manager');
 
     return new static($container->get('entity.manager'), $container->get('string_translation'), $container->get('current_user'), $container->get('plugin.manager.plugin.plugin_selector'), $plugin_type_manager->getPluginType('payment_method'));

--- a/modules/payment_form/src/Plugin/Payment/Type/PaymentFormConfigurationForm.php
+++ b/modules/payment_form/src/Plugin/Payment/Type/PaymentFormConfigurationForm.php
@@ -14,7 +14,7 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\payment\Plugin\Payment\Method\PaymentMethodManagerInterface;
-use Drupal\plugin\PluginTypeInterface;
+use Drupal\plugin\PluginType\PluginTypeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -32,7 +32,7 @@ class PaymentFormConfigurationForm extends ConfigFormBase {
   /**
    * The plugin selector plugin type.
    *
-   * @var \Drupal\plugin\PluginTypeInterface
+   * @var \Drupal\plugin\PluginType\PluginTypeInterface
    */
   protected $pluginSelectorType;
 
@@ -42,7 +42,7 @@ class PaymentFormConfigurationForm extends ConfigFormBase {
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    * @param \Drupal\payment\Plugin\Payment\Method\PaymentMethodManagerInterface $payment_method_manager
-   * @param \Drupal\plugin\PluginTypeInterface $plugin_selector_type
+   * @param \Drupal\plugin\PluginType\PluginTypeInterface $plugin_selector_type
    */
   public function __construct(ConfigFactoryInterface $config_factory, TranslationInterface $string_translation, PaymentMethodManagerInterface $payment_method_manager, PluginTypeInterface $plugin_selector_type) {
     parent::__construct($config_factory);
@@ -55,7 +55,7 @@ class PaymentFormConfigurationForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    /** @var \Drupal\plugin\PluginTypeManagerInterface $plugin_type_manager */
+    /** @var \Drupal\plugin\PluginType\PluginTypeManagerInterface $plugin_type_manager */
     $plugin_type_manager = $container->get('plugin.plugin_type_manager');
 
     return new static(

--- a/modules/payment_form/tests/src/Unit/Entity/Payment/PaymentFormTest.php
+++ b/modules/payment_form/tests/src/Unit/Entity/Payment/PaymentFormTest.php
@@ -24,8 +24,8 @@ use Drupal\payment\Response\Response;
 use Drupal\payment_form\Entity\Payment\PaymentForm;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorInterface;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
-use Drupal\plugin\PluginType;
-use Drupal\plugin\PluginTypeManagerInterface;
+use Drupal\plugin\PluginType\PluginType;
+use Drupal\plugin\PluginType\PluginTypeManagerInterface;
 use Drupal\Tests\payment\Unit\PHPUnitStubMap;
 use Drupal\Tests\UnitTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -91,7 +91,7 @@ class PaymentFormTest extends UnitTestCase {
   /**
    * The payment method plugin type.
    *
-   * @var \Drupal\plugin\PluginTypeInterface
+   * @var \Drupal\plugin\PluginType\PluginTypeInterface
    */
   protected $paymentMethodType;
 

--- a/modules/payment_form/tests/src/Unit/Plugin/Field/FieldFormatter/PaymentFormTest.php
+++ b/modules/payment_form/tests/src/Unit/Plugin/Field/FieldFormatter/PaymentFormTest.php
@@ -266,7 +266,7 @@ class PaymentFormTest extends UnitTestCase {
       ->with($payment, 'payment_form')
       ->willReturn($form);
 
-    $this->assertSame($form, $this->sut->viewElements($items));
+    $this->assertSame($form, $this->sut->viewElements($items, 'en'));
   }
 
 }

--- a/modules/payment_form/tests/src/Unit/Plugin/Payment/Type/PaymentFormConfigurationFormTest.php
+++ b/modules/payment_form/tests/src/Unit/Plugin/Payment/Type/PaymentFormConfigurationFormTest.php
@@ -14,8 +14,8 @@ namespace Drupal\Tests\payment_form\Unit\Plugin\Payment\Type {
   use Drupal\payment_form\Plugin\Payment\Type\PaymentFormConfigurationForm;
   use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorInterface;
   use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
-  use Drupal\plugin\PluginType;
-  use Drupal\plugin\PluginTypeManagerInterface;
+  use Drupal\plugin\PluginType\PluginType;
+  use Drupal\plugin\PluginType\PluginTypeManagerInterface;
   use Drupal\Tests\UnitTestCase;
   use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -66,7 +66,7 @@ namespace Drupal\Tests\payment_form\Unit\Plugin\Payment\Type {
     /**
      * The plugin selector plugin type.
      *
-     * @var \Drupal\plugin\PluginTypeInterface
+     * @var \Drupal\plugin\PluginType\PluginTypeInterface
      */
     protected $pluginSelectorType;
 

--- a/modules/payment_reference/src/Element/PaymentReference.php
+++ b/modules/payment_reference/src/Element/PaymentReference.php
@@ -17,7 +17,7 @@ use Drupal\Core\Utility\LinkGeneratorInterface;
 use Drupal\payment\Element\PaymentReferenceBase;
 use Drupal\payment\QueueInterface;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
-use Drupal\plugin\PluginTypeInterface;
+use Drupal\plugin\PluginType\PluginTypeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -52,7 +52,7 @@ class PaymentReference extends PaymentReferenceBase {
    * @param \Drupal\Core\Render\RendererInterface $renderer
    * @param \Drupal\Core\Session\AccountInterface $current_user
    * @param \Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface $plugin_selector_manager
-   * @param \Drupal\plugin\PluginTypeInterface $payment_method_type
+   * @param \Drupal\plugin\PluginType\PluginTypeInterface $payment_method_type
    * @param \Drupal\payment\QueueInterface $payment_queue
    */
   public function __construct($configuration, $plugin_id, $plugin_definition, RequestStack $request_stack, EntityStorageInterface $payment_storage, TranslationInterface $string_translation, DateFormatter $date_formatter, LinkGeneratorInterface $link_generator, RendererInterface $renderer, AccountInterface $current_user, PluginSelectorManagerInterface $plugin_selector_manager, PluginTypeInterface $payment_method_type, Random $random, QueueInterface $payment_queue) {
@@ -67,7 +67,7 @@ class PaymentReference extends PaymentReferenceBase {
     /** @var \Drupal\Core\Entity\EntityManagerInterface $entity_manager */
     $entity_manager = $container->get('entity.manager');
 
-    /** @var \Drupal\plugin\PluginTypeManagerInterface $plugin_type_manager */
+    /** @var \Drupal\plugin\PluginType\PluginTypeManagerInterface $plugin_type_manager */
     $plugin_type_manager = $container->get('plugin.plugin_type_manager');
 
     return new static($configuration, $plugin_id, $plugin_definition, $container->get('request_stack'), $entity_manager->getStorage('payment'), $container->get('string_translation'), $container->get('date.formatter'), $container->get('link_generator'), $container->get('renderer'), $container->get('current_user'), $container->get('plugin.manager.plugin.plugin_selector'), $plugin_type_manager->getPluginType('payment_method'), new Random(), $container->get('payment_reference.queue'));

--- a/modules/payment_reference/src/Plugin/Payment/Type/PaymentReferenceConfigurationForm.php
+++ b/modules/payment_reference/src/Plugin/Payment/Type/PaymentReferenceConfigurationForm.php
@@ -13,7 +13,7 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\payment\Plugin\Payment\Method\PaymentMethodManagerInterface;
-use Drupal\plugin\PluginTypeInterface;
+use Drupal\plugin\PluginType\PluginTypeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -31,7 +31,7 @@ class PaymentReferenceConfigurationForm extends ConfigFormBase {
   /**
    * The plugin selector plugin type.
    *
-   * @var \Drupal\plugin\PluginTypeInterface
+   * @var \Drupal\plugin\PluginType\PluginTypeInterface
    */
   protected $pluginSelectorType;
 
@@ -41,7 +41,7 @@ class PaymentReferenceConfigurationForm extends ConfigFormBase {
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    * @param \Drupal\payment\Plugin\Payment\Method\PaymentMethodManagerInterface $payment_method_manager
-   * @param \Drupal\plugin\PluginTypeInterface $plugin_selector_type
+   * @param \Drupal\plugin\PluginType\PluginTypeInterface $plugin_selector_type
    */
   public function __construct(ConfigFactoryInterface $config_factory, TranslationInterface $string_translation, PaymentMethodManagerInterface $payment_method_manager, PluginTypeInterface $plugin_selector_type) {
     parent::__construct($config_factory);
@@ -54,7 +54,7 @@ class PaymentReferenceConfigurationForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    /** @var \Drupal\plugin\PluginTypeManagerInterface $plugin_type_manager */
+    /** @var \Drupal\plugin\PluginType\PluginTypeManagerInterface $plugin_type_manager */
     $plugin_type_manager = $container->get('plugin.plugin_type_manager');
 
     return new static(

--- a/modules/payment_reference/tests/src/Unit/Element/PaymentReferenceTest.php
+++ b/modules/payment_reference/tests/src/Unit/Element/PaymentReferenceTest.php
@@ -20,8 +20,8 @@ use Drupal\payment\Plugin\Payment\Method\PaymentMethodManagerInterface;
 use Drupal\payment\QueueInterface;
 use Drupal\payment_reference\Element\PaymentReference;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
-use Drupal\plugin\PluginType;
-use Drupal\plugin\PluginTypeManagerInterface;
+use Drupal\plugin\PluginType\PluginType;
+use Drupal\plugin\PluginType\PluginTypeManagerInterface;
 use Drupal\Tests\UnitTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -64,7 +64,7 @@ class PaymentReferenceTest extends UnitTestCase {
   /**
    * The payment method type.
    *
-   * @var \Drupal\plugin\PluginTypeInterface
+   * @var \Drupal\plugin\PluginType\PluginTypeInterface
    */
   protected $paymentMethodType;
 

--- a/modules/payment_reference/tests/src/Unit/Plugin/Payment/Type/PaymentReferenceConfigurationFormTest.php
+++ b/modules/payment_reference/tests/src/Unit/Plugin/Payment/Type/PaymentReferenceConfigurationFormTest.php
@@ -14,8 +14,8 @@ namespace Drupal\Tests\payment_reference\Unit\Plugin\Payment\Type {
   use Drupal\payment_reference\Plugin\Payment\Type\PaymentReferenceConfigurationForm;
   use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorInterface;
   use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
-  use Drupal\plugin\PluginType;
-  use Drupal\plugin\PluginTypeManagerInterface;
+  use Drupal\plugin\PluginType\PluginType;
+  use Drupal\plugin\PluginType\PluginTypeManagerInterface;
   use Drupal\Tests\UnitTestCase;
   use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -66,7 +66,7 @@ namespace Drupal\Tests\payment_reference\Unit\Plugin\Payment\Type {
     /**
      * The plugin selector plugin type.
      *
-     * @var \Drupal\plugin\PluginTypeInterface
+     * @var \Drupal\plugin\PluginType\PluginTypeInterface
      */
     protected $pluginSelectorType;
 

--- a/src/Element/PaymentReferenceBase.php
+++ b/src/Element/PaymentReferenceBase.php
@@ -31,7 +31,7 @@ use Drupal\payment\Entity\PaymentInterface;
 use Drupal\payment\Plugin\Payment\Method\PaymentExecutionPaymentMethodManager;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
 use Drupal\plugin\PluginDiscovery\LimitedPluginDiscoveryDecorator;
-use Drupal\plugin\PluginTypeInterface;
+use Drupal\plugin\PluginType\PluginTypeInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -75,7 +75,7 @@ abstract class PaymentReferenceBase extends FormElement implements FormElementIn
   /**
    * The payment method type.
    *
-   * @var \Drupal\plugin\PluginTypeInterface
+   * @var \Drupal\plugin\PluginType\PluginTypeInterface
    */
   protected $paymentMethodType;
 
@@ -131,7 +131,7 @@ abstract class PaymentReferenceBase extends FormElement implements FormElementIn
    * @param \Drupal\Core\Render\RendererInterface $renderer
    * @param \Drupal\Core\Session\AccountInterface $current_user
    * @param \Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface $plugin_selector_manager
-   * @param \Drupal\plugin\PluginTypeInterface $payment_method_type
+   * @param \Drupal\plugin\PluginType\PluginTypeInterface $payment_method_type
    * @param \Drupal\Component\Utility\Random $random
    */
   public function __construct(array $configuration, $plugin_id, array $plugin_definition, RequestStack $request_stack, EntityStorageInterface $payment_storage, TranslationInterface $string_translation, DateFormatter $date_formatter, LinkGeneratorInterface $link_generator, RendererInterface $renderer, AccountInterface $current_user, PluginSelectorManagerInterface $plugin_selector_manager, PluginTypeInterface $payment_method_type, Random $random) {

--- a/src/Entity/Payment/PaymentListBuilder.php
+++ b/src/Entity/Payment/PaymentListBuilder.php
@@ -134,8 +134,12 @@ class PaymentListBuilder extends EntityListBuilder implements PaymentListBuilder
       'sort' => 'DESC',
       'specifier' => 'changed',
     ];
-    $header['status'] = $this->t('Status');
-    $header['amount'] =$this-> t('Amount');
+    $header['status'] = [
+      'data' => $this->t('Status'),
+    ];
+    $header['amount'] = [
+      'data' => $this-> t('Amount'),
+    ];
     $header['payment_method'] = array(
       'data' => $this->t('Payment method'),
       'class' => array(RESPONSIVE_PRIORITY_LOW),
@@ -144,7 +148,9 @@ class PaymentListBuilder extends EntityListBuilder implements PaymentListBuilder
       'data' => $this->t('Payer'),
       'class' => array(RESPONSIVE_PRIORITY_MEDIUM),
     );
-    $header['operations'] = $this->t('Operations');
+    $header['operations'] = [
+      'data' => $this->t('Operations'),
+    ];
 
     return $header;
   }

--- a/src/Entity/Payment/PaymentStatusForm.php
+++ b/src/Entity/Payment/PaymentStatusForm.php
@@ -16,7 +16,7 @@ use Drupal\payment\Plugin\Payment\Method\PaymentMethodUpdatePaymentStatusInterfa
 use Drupal\payment\Plugin\Payment\PaymentAwarePluginManagerDecorator;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
 use Drupal\plugin\PluginDiscovery\LimitedPluginDiscoveryDecorator;
-use Drupal\plugin\PluginTypeManagerInterface;
+use Drupal\plugin\PluginType\PluginTypeManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -34,7 +34,7 @@ class PaymentStatusForm extends EntityForm {
   /**
    * The plugin type manager.
    *
-   * @var \Drupal\plugin\PluginTypeManagerInterface
+   * @var \Drupal\plugin\PluginType\PluginTypeManagerInterface
    */
   protected $pluginTypeManager;
 
@@ -48,7 +48,7 @@ class PaymentStatusForm extends EntityForm {
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    *    The string translator.
    * @param \Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface $plugin_selector_manager
-   * @param \Drupal\plugin\PluginTypeManagerInterface $plugin_type_manager
+   * @param \Drupal\plugin\PluginType\PluginTypeManagerInterface $plugin_type_manager
    *   The plugin type manager.
    */
   function __construct(AccountInterface $current_user, UrlGeneratorInterface $url_generator, TranslationInterface $string_translation, PluginSelectorManagerInterface $plugin_selector_manager, PluginTypeManagerInterface $plugin_type_manager) {

--- a/src/Entity/PaymentMethodConfiguration/PaymentMethodConfigurationListBuilder.php
+++ b/src/Entity/PaymentMethodConfiguration/PaymentMethodConfigurationListBuilder.php
@@ -63,8 +63,12 @@ class PaymentMethodConfigurationListBuilder extends ConfigEntityListBuilder {
    * {@inheritdoc}
    */
   public function buildHeader() {
-    $row['label'] = $this->t('Name');
-    $row['plugin'] = $this->t('Type');
+    $row['label'] = [
+      'data' => $this->t('Name'),
+    ];
+    $row['plugin'] = [
+      'data' => $this->t('Type'),
+    ];
     $row['owner'] = array(
       'data' => $this->t('Owner'),
       'class' => array(RESPONSIVE_PRIORITY_LOW),
@@ -73,7 +77,9 @@ class PaymentMethodConfigurationListBuilder extends ConfigEntityListBuilder {
       'data' => $this->t('Status'),
       'class' => array(RESPONSIVE_PRIORITY_MEDIUM),
     );
-    $row['operations'] = $this->t('Operations');
+    $row['operations'] = [
+      'data' => $this->t('Operations'),
+    ];
 
     return $row;
   }

--- a/src/Entity/PaymentStatus/PaymentStatusForm.php
+++ b/src/Entity/PaymentStatus/PaymentStatusForm.php
@@ -13,7 +13,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
-use Drupal\plugin\PluginTypeManagerInterface;
+use Drupal\plugin\PluginType\PluginTypeManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -38,7 +38,7 @@ class PaymentStatusForm extends EntityForm {
   /**
    * The plugin type manager.
    *
-   * @var \Drupal\plugin\PluginTypeManagerInterface
+   * @var \Drupal\plugin\PluginType\PluginTypeManagerInterface
    */
   protected $pluginTypeManager;
 
@@ -51,7 +51,7 @@ class PaymentStatusForm extends EntityForm {
    *   The payment status storage.
    * @param \Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface $plugin_selector_manager
    *   The plugin selector manager.
-   * @param \Drupal\plugin\PluginTypeManagerInterface $plugin_type_manager
+   * @param \Drupal\plugin\PluginType\PluginTypeManagerInterface $plugin_type_manager
    *   The plugin type manager.
    */
   public function __construct(TranslationInterface $string_translation, EntityStorageInterface $payment_status_storage, PluginSelectorManagerInterface $plugin_selector_manager, PluginTypeManagerInterface $plugin_type_manager) {

--- a/src/Plugin/Action/SetStatus.php
+++ b/src/Plugin/Action/SetStatus.php
@@ -15,7 +15,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\payment\Entity\PaymentInterface;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
-use Drupal\plugin\PluginTypeInterface;
+use Drupal\plugin\PluginType\PluginTypeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -32,7 +32,7 @@ class SetStatus extends ConfigurableActionBase implements ContainerFactoryPlugin
   /**
    * The payment status type.
    *
-   * @var \Drupal\plugin\PluginTypeInterface
+   * @var \Drupal\plugin\PluginType\PluginTypeInterface
    */
   protected $paymentStatusType;
 
@@ -56,7 +56,7 @@ class SetStatus extends ConfigurableActionBase implements ContainerFactoryPlugin
    *   The string translator.
    * @param \Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface $plugin_selector_manager
    *   The plugin selector manager.
-   * @param \Drupal\plugin\PluginTypeInterface $payment_status_type
+   * @param \Drupal\plugin\PluginType\PluginTypeInterface $payment_status_type
    *   The payment status type.
    */
   public function __construct(array $configuration, $plugin_id, array $plugin_definition, TranslationInterface $string_translation, PluginSelectorManagerInterface $plugin_selector_manager, PluginTypeInterface $payment_status_type) {
@@ -70,7 +70,7 @@ class SetStatus extends ConfigurableActionBase implements ContainerFactoryPlugin
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    /** @var \Drupal\plugin\PluginTypeManagerInterface $plugin_type_manager */
+    /** @var \Drupal\plugin\PluginType\PluginTypeManagerInterface $plugin_type_manager */
     $plugin_type_manager = $container->get('plugin.plugin_type_manager');
 
     return new static($configuration, $plugin_id, $plugin_definition, $container->get('string_translation'), $container->get('plugin.manager.plugin.plugin_selector'), $plugin_type_manager->getPluginType('payment_status'));

--- a/src/Plugin/Payment/MethodConfiguration/Basic.php
+++ b/src/Plugin/Payment/MethodConfiguration/Basic.php
@@ -13,7 +13,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
-use Drupal\plugin\PluginTypeInterface;
+use Drupal\plugin\PluginType\PluginTypeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -34,7 +34,7 @@ class Basic extends PaymentMethodConfigurationBase implements ContainerFactoryPl
   /**
    * The payment status plugin type.
    *
-   * @var \Drupal\plugin\PluginTypeInterface
+   * @var \Drupal\plugin\PluginType\PluginTypeInterface
    */
   protected $paymentStatusType;
 
@@ -60,7 +60,7 @@ class Basic extends PaymentMethodConfigurationBase implements ContainerFactoryPl
    *   The module handler.
    * @param \Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface
    *   The plugin selector manager.
-   * @param \Drupal\plugin\PluginTypeInterface $payment_status_type
+   * @param \Drupal\plugin\PluginType\PluginTypeInterface $payment_status_type
    *   The payment status plugin type.
    */
   public function __construct(array $configuration, $plugin_id, array $plugin_definition, TranslationInterface $string_translation, ModuleHandlerInterface $module_handler, PluginSelectorManagerInterface $plugin_selector_manager, PluginTypeInterface $payment_status_type) {
@@ -74,7 +74,7 @@ class Basic extends PaymentMethodConfigurationBase implements ContainerFactoryPl
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    /** @var \Drupal\plugin\PluginTypeManagerInterface $plugin_type_manager */
+    /** @var \Drupal\plugin\PluginType\PluginTypeManagerInterface $plugin_type_manager */
     $plugin_type_manager = $container->get('plugin.plugin_type_manager');
 
     return new static($configuration, $plugin_id, $plugin_definition, $container->get('string_translation'), $container->get('module_handler'), $container->get('plugin.manager.plugin.plugin_selector'), $plugin_type_manager->getPluginType('payment_status'));

--- a/tests/src/Unit/Controller/AddPaymentMethodConfigurationTest.php
+++ b/tests/src/Unit/Controller/AddPaymentMethodConfigurationTest.php
@@ -14,6 +14,7 @@ use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\payment\Controller\AddPaymentMethodConfiguration;
 use Drupal\payment\Entity\PaymentMethodConfigurationInterface;
 use Drupal\payment\Plugin\Payment\MethodConfiguration\PaymentMethodConfigurationManagerInterface;
@@ -193,7 +194,7 @@ class AddPaymentMethodConfigurationTest extends UnitTestCase {
         'label' => $this->randomMachineName(),
       ]);
 
-    $this->assertInternalType('string', $this->sut->title($plugin_id));
+    $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->title($plugin_id));
   }
 
 }

--- a/tests/src/Unit/Controller/DuplicatePaymentMethodConfigurationTest.php
+++ b/tests/src/Unit/Controller/DuplicatePaymentMethodConfigurationTest.php
@@ -104,7 +104,7 @@ class DuplicatePaymentMethodConfigurationTest extends UnitTestCase {
       ->method('label')
       ->willReturn($label);
 
-    $this->assertContains($label, $this->sut->title($payment_method_configuration));
+    $this->assertContains($label, (string) $this->sut->title($payment_method_configuration));
   }
 
 }

--- a/tests/src/Unit/Controller/EditPaymentMethodConfigurationTest.php
+++ b/tests/src/Unit/Controller/EditPaymentMethodConfigurationTest.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\Tests\payment\Unit\Controller;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\payment\Controller\EditPaymentMethodConfiguration;
 use Drupal\payment\Entity\PaymentMethodConfigurationInterface;
 use Drupal\Tests\UnitTestCase;
@@ -69,7 +70,7 @@ class EditPaymentMethodConfigurationTest extends UnitTestCase {
     $payment_method_configuration->expects($this->once())
       ->method('label');
 
-    $this->assertInternalType('string', $this->sut->title($payment_method_configuration));
+    $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->title($payment_method_configuration));
   }
 
 }

--- a/tests/src/Unit/Controller/EditPaymentStatusTest.php
+++ b/tests/src/Unit/Controller/EditPaymentStatusTest.php
@@ -70,7 +70,7 @@ class EditPaymentStatusTest extends UnitTestCase {
       ->method('label')
       ->willReturn($label);
 
-    $this->assertContains($label, $this->sut->title($payment_status));
+    $this->assertContains($label, (string) $this->sut->title($payment_status));
   }
 
 }

--- a/tests/src/Unit/Controller/EditPaymentTest.php
+++ b/tests/src/Unit/Controller/EditPaymentTest.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\Tests\payment\Unit\Controller;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\payment\Controller\EditPayment;
 use Drupal\payment\Entity\PaymentInterface;
 use Drupal\Tests\UnitTestCase;
@@ -65,7 +66,7 @@ class EditPaymentTest extends UnitTestCase {
     $payment->expects($this->atLeastOnce())
       ->method('id');
 
-    $this->assertInternalType('string', $this->sut->title($payment));
+    $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->title($payment));
   }
 
 }

--- a/tests/src/Unit/Controller/ListPaymentStatusesTest.php
+++ b/tests/src/Unit/Controller/ListPaymentStatusesTest.php
@@ -137,6 +137,10 @@ class ListPaymentStatusesTest extends UnitTestCase {
       ->will($this->returnArgument(0));
 
     $build = $this->sut->execute();
+    foreach ($build['#header'] as $key => $label) {
+      $build['#header'][$key] = (string) $label;
+    }
+
     $expected = [
       '#header' => ['Title', 'Description', 'Operations'],
       '#type' => 'table',

--- a/tests/src/Unit/Controller/ViewPaymentTest.php
+++ b/tests/src/Unit/Controller/ViewPaymentTest.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\Tests\payment\Unit\Controller;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\payment\Controller\ViewPayment;
 use Drupal\payment\Entity\PaymentInterface;
 use Drupal\Tests\UnitTestCase;
@@ -65,7 +66,7 @@ class ViewPaymentTest extends UnitTestCase {
     $payment->expects($this->once())
       ->method('id');
 
-    $this->assertInternalType('string', $this->sut->title($payment));
+    $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->title($payment));
   }
 
 }

--- a/tests/src/Unit/Element/PaymentReferenceBaseTest.php
+++ b/tests/src/Unit/Element/PaymentReferenceBaseTest.php
@@ -32,7 +32,7 @@ namespace Drupal\Tests\payment\Unit\Element {
   use Drupal\payment\QueueInterface;
   use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorInterface;
   use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
-  use Drupal\plugin\PluginType;
+  use Drupal\plugin\PluginType\PluginType;
   use Drupal\Tests\UnitTestCase;
   use Symfony\Component\DependencyInjection\ContainerInterface;
   use Symfony\Component\HttpFoundation\Request;
@@ -76,7 +76,7 @@ namespace Drupal\Tests\payment\Unit\Element {
     /**
      * The payment method type.
      *
-     * @var \Drupal\plugin\PluginTypeInterface
+     * @var \Drupal\plugin\PluginType\PluginTypeInterface
      */
     protected $paymentMethodType;
 

--- a/tests/src/Unit/Entity/Payment/PaymentAccessControlHandlerTest.php
+++ b/tests/src/Unit/Entity/Payment/PaymentAccessControlHandlerTest.php
@@ -41,6 +41,9 @@ class PaymentAccessControlHandlerTest extends UnitTestCase {
     $cache_context_manager = $this->getMockBuilder(CacheContextsManager::class)
       ->disableOriginalConstructor()
       ->getMock();
+    $cache_context_manager->expects($this->any())
+      ->method('assertValidTokens')
+      ->willReturn(TRUE);
 
     $container = new Container();
     $container->set('cache_contexts_manager', $cache_context_manager);

--- a/tests/src/Unit/Entity/Payment/PaymentCaptureFormTest.php
+++ b/tests/src/Unit/Entity/Payment/PaymentCaptureFormTest.php
@@ -9,6 +9,7 @@ namespace Drupal\Tests\payment\Unit\Entity\Payment;
 
 use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\payment\Entity\Payment\PaymentCaptureForm;
 use Drupal\payment\Entity\PaymentInterface;
@@ -90,14 +91,14 @@ class PaymentCaptureFormTest extends UnitTestCase {
    * @covers ::getConfirmText
    */
   function testGetConfirmText() {
-    $this->assertInternalType('string', $this->sut->getConfirmText());
+    $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->getConfirmText());
   }
 
   /**
    * @covers ::getQuestion
    */
   function testGetQuestion() {
-    $this->assertInternalType('string', $this->sut->getQuestion());
+    $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->getQuestion());
   }
 
   /**

--- a/tests/src/Unit/Entity/Payment/PaymentDeleteFormTest.php
+++ b/tests/src/Unit/Entity/Payment/PaymentDeleteFormTest.php
@@ -9,6 +9,7 @@ namespace Drupal\Tests\payment\Unit\Entity\Payment {
 
   use Drupal\Core\Entity\EntityManagerInterface;
   use Drupal\Core\Form\FormStateInterface;
+  use Drupal\Core\StringTranslation\TranslatableMarkup;
   use Drupal\Core\Url;
   use Drupal\payment\Entity\Payment\PaymentDeleteForm;
   use Drupal\payment\Entity\PaymentInterface;
@@ -97,14 +98,14 @@ namespace Drupal\Tests\payment\Unit\Entity\Payment {
      * @covers ::getQuestion
      */
     function testGetQuestion() {
-      $this->assertInternalType('string', $this->sut->getQuestion());
+      $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->getQuestion());
     }
 
     /**
      * @covers ::getConfirmText
      */
     function testGetConfirmText() {
-      $this->assertInternalType('string', $this->sut->getConfirmText());
+      $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->getConfirmText());
     }
 
     /**

--- a/tests/src/Unit/Entity/Payment/PaymentRefundFormTest.php
+++ b/tests/src/Unit/Entity/Payment/PaymentRefundFormTest.php
@@ -9,6 +9,7 @@ namespace Drupal\Tests\payment\Unit\Entity\Payment;
 
 use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\payment\Entity\Payment\PaymentRefundForm;
 use Drupal\payment\Entity\PaymentInterface;
@@ -90,14 +91,14 @@ class PaymentRefundFormTest extends UnitTestCase {
    * @covers ::getConfirmText
    */
   function testGetConfirmText() {
-    $this->assertInternalType('string', $this->sut->getConfirmText());
+    $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->getConfirmText());
   }
 
   /**
    * @covers ::getQuestion
    */
   function testGetQuestion() {
-    $this->assertInternalType('string', $this->sut->getQuestion());
+    $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->getQuestion());
   }
 
   /**

--- a/tests/src/Unit/Entity/Payment/PaymentStatusFormTest.php
+++ b/tests/src/Unit/Entity/Payment/PaymentStatusFormTest.php
@@ -22,8 +22,8 @@ use Drupal\payment\Plugin\Payment\Status\PaymentStatusInterface;
 use Drupal\payment\Plugin\Payment\Status\PaymentStatusManagerInterface;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorInterface;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
-use Drupal\plugin\PluginType;
-use Drupal\plugin\PluginTypeManagerInterface;
+use Drupal\plugin\PluginType\PluginType;
+use Drupal\plugin\PluginType\PluginTypeManagerInterface;
 use Drupal\Tests\UnitTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -72,7 +72,7 @@ class PaymentStatusFormTest extends UnitTestCase {
   /**
    * The plugin type manager.
    *
-   * @var \Drupal\plugin\PluginTypeManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+   * @var \Drupal\plugin\PluginType\PluginTypeManagerInterface|\PHPUnit_Framework_MockObject_MockObject
    */
   protected $pluginTypeManager;
 

--- a/tests/src/Unit/Entity/PaymentMethodConfiguration/PaymentMethodConfigurationAccessControlHandlerTest.php
+++ b/tests/src/Unit/Entity/PaymentMethodConfiguration/PaymentMethodConfigurationAccessControlHandlerTest.php
@@ -46,6 +46,9 @@ class PaymentMethodConfigurationAccessControlHandlerTest extends UnitTestCase {
     $cache_context_manager = $this->getMockBuilder(CacheContextsManager::class)
       ->disableOriginalConstructor()
       ->getMock();
+    $cache_context_manager->expects($this->any())
+      ->method('assertValidTokens')
+      ->willReturn(TRUE);
 
     $container = new Container();
     $container->set('cache_contexts_manager', $cache_context_manager);
@@ -274,10 +277,15 @@ class PaymentMethodConfigurationAccessControlHandlerTest extends UnitTestCase {
       ->method('hasPermission')
       ->willReturnMap($map);
 
+    $language = $this->getMock(LanguageInterface::class);
+
     $payment_method_configuration = $this->getMockPaymentMethodConfiguration();
     $payment_method_configuration->expects($this->atLeastOnce())
       ->method('bundle')
       ->willReturn($bundle);
+    $payment_method_configuration->expects($this->any())
+      ->method('language')
+      ->willReturn($language);
 
     $class = new \ReflectionClass($this->sut);
     $method = $class->getMethod('checkAccess');

--- a/tests/src/Unit/Entity/PaymentMethodConfiguration/PaymentMethodConfigurationDeleteFormTest.php
+++ b/tests/src/Unit/Entity/PaymentMethodConfiguration/PaymentMethodConfigurationDeleteFormTest.php
@@ -8,6 +8,7 @@
 namespace Drupal\Tests\payment\Unit\Entity\PaymentMethodConfiguration {
 
   use Drupal\Core\Form\FormStateInterface;
+  use Drupal\Core\StringTranslation\TranslatableMarkup;
   use Drupal\Core\Url;
   use Drupal\payment\Entity\PaymentMethodConfiguration;
   use Drupal\payment\Entity\PaymentMethodConfiguration\PaymentMethodConfigurationDeleteForm;
@@ -88,14 +89,14 @@ namespace Drupal\Tests\payment\Unit\Entity\PaymentMethodConfiguration {
      * @covers ::getQuestion
      */
     function testGetQuestion() {
-      $this->assertInternalType('string', $this->sut->getQuestion());
+      $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->getQuestion());
     }
 
     /**
      * @covers ::getConfirmText
      */
     function testGetConfirmText() {
-      $this->assertInternalType('string', $this->sut->getConfirmText());
+      $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->getConfirmText());
     }
 
     /**

--- a/tests/src/Unit/Entity/PaymentStatus/PaymentStatusDeleteFormTest.php
+++ b/tests/src/Unit/Entity/PaymentStatus/PaymentStatusDeleteFormTest.php
@@ -8,6 +8,7 @@
 namespace Drupal\Tests\payment\Unit\Entity\PaymentStatus {
 
   use Drupal\Core\Form\FormStateInterface;
+  use Drupal\Core\StringTranslation\TranslatableMarkup;
   use Drupal\Core\Url;
   use Drupal\payment\Entity\PaymentStatus\PaymentStatusDeleteForm;
   use Drupal\payment\Entity\PaymentStatusInterface;
@@ -86,14 +87,14 @@ namespace Drupal\Tests\payment\Unit\Entity\PaymentStatus {
      * @covers ::getQuestion
      */
     function testGetQuestion() {
-      $this->assertInternalType('string', $this->sut->getQuestion());
+      $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->getQuestion());
     }
 
     /**
      * @covers ::getConfirmText
      */
     function testGetConfirmText() {
-      $this->assertInternalType('string', $this->sut->getConfirmText());
+      $this->assertInstanceOf(TranslatableMarkup::class, $this->sut->getConfirmText());
     }
 
     /**

--- a/tests/src/Unit/Entity/PaymentStatus/PaymentStatusFormTest.php
+++ b/tests/src/Unit/Entity/PaymentStatus/PaymentStatusFormTest.php
@@ -18,8 +18,8 @@ namespace Drupal\Tests\payment\Unit\Entity\PaymentStatus {
   use Drupal\payment\Plugin\Payment\Status\PaymentStatusManagerInterface;
   use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorInterface;
   use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
-  use Drupal\plugin\PluginType;
-  use Drupal\plugin\PluginTypeManagerInterface;
+  use Drupal\plugin\PluginType\PluginType;
+  use Drupal\plugin\PluginType\PluginTypeManagerInterface;
   use Drupal\Tests\UnitTestCase;
   use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -61,7 +61,7 @@ namespace Drupal\Tests\payment\Unit\Entity\PaymentStatus {
     /**
      * The plugin type manager.
      *
-     * @var \Drupal\plugin\PluginTypeManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Drupal\plugin\PluginType\PluginTypeManagerInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $pluginTypeManager;
 

--- a/tests/src/Unit/Entity/PaymentStatus/PaymentStatusFormTest.php
+++ b/tests/src/Unit/Entity/PaymentStatus/PaymentStatusFormTest.php
@@ -187,34 +187,35 @@ namespace Drupal\Tests\payment\Unit\Entity\PaymentStatus {
       $build = $this->sut->form([], $form_state);
       unset($build['#process']);
       unset($build['langcode']);
-      $expected_build = array(
-        'label' => array(
-          '#type' => 'textfield',
-          '#title' => 'Label',
-          '#default_value' => $label,
-          '#maxlength' => 255,
-          '#required' => TRUE,
+
+      $expected_build['label'] = [
+        '#type' => 'textfield',
+        '#default_value' => $label,
+        '#maxlength' => 255,
+        '#required' => TRUE,
+      ];
+      unset($build['label']['#title']);
+      $expected_build['id'] = [
+        '#default_value' => $id,
+        '#disabled' => !$is_new,
+        '#machine_name' => array(
+          'source' => array('label'),
+          'exists' => array($this->sut, 'PaymentStatusIdExists'),
         ),
-        'id' => array(
-          '#default_value' => $id,
-          '#disabled' => !$is_new,
-          '#machine_name' => array(
-            'source' => array('label'),
-            'exists' => array($this->sut, 'PaymentStatusIdExists'),
-          ),
-          '#maxlength' => 255,
-          '#type' => 'machine_name',
-          '#required' => TRUE,
-        ),
-        'parent_id' => $parent_selector_form,
-        'description' => array(
-          '#type' => 'textarea',
-          '#title' => 'Description',
-          '#default_value' => $description,
-          '#maxlength' => 255,
-        ),
-        '#after_build' => ['::afterBuild'],
-      );
+        '#maxlength' => 255,
+        '#type' => 'machine_name',
+        '#required' => TRUE,
+      ];
+      unset($build['id']['#title']);
+      $expected_build['parent_id'] = $parent_selector_form;
+      $expected_build['description'] = [
+        '#type' => 'textarea',
+        '#default_value' => $description,
+        '#maxlength' => 255,
+      ];
+      unset($build['description']['#title']);
+      $expected_build['#after_build'] = ['::afterBuild'];
+
       $this->assertSame($expected_build, $build);
     }
 

--- a/tests/src/Unit/Plugin/Action/SetStatusTest.php
+++ b/tests/src/Unit/Plugin/Action/SetStatusTest.php
@@ -17,8 +17,8 @@ use Drupal\payment\Plugin\Payment\Status\PaymentStatusInterface;
 use Drupal\payment\Plugin\Payment\Status\PaymentStatusManagerInterface;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorInterface;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
-use Drupal\plugin\PluginType;
-use Drupal\plugin\PluginTypeManagerInterface;
+use Drupal\plugin\PluginType\PluginType;
+use Drupal\plugin\PluginType\PluginTypeManagerInterface;
 use Drupal\Tests\UnitTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -39,7 +39,7 @@ class SetStatusTest extends UnitTestCase {
   /**
    * The payment status type.
    *
-   * @var \Drupal\plugin\PluginTypeInterface
+   * @var \Drupal\plugin\PluginType\PluginTypeInterface
    */
   protected $paymentStatusType;
 

--- a/tests/src/Unit/Plugin/Payment/MethodConfiguration/BasicTest.php
+++ b/tests/src/Unit/Plugin/Payment/MethodConfiguration/BasicTest.php
@@ -14,8 +14,8 @@ use Drupal\payment\Plugin\Payment\Status\PaymentStatusInterface;
 use Drupal\payment\Plugin\Payment\Status\PaymentStatusManagerInterface;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorInterface;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\PluginSelectorManagerInterface;
-use Drupal\plugin\PluginType;
-use Drupal\plugin\PluginTypeManagerInterface;
+use Drupal\plugin\PluginType\PluginType;
+use Drupal\plugin\PluginType\PluginTypeManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -35,7 +35,7 @@ class BasicTest extends PaymentMethodConfigurationBaseTestBase {
   /**
    * The payment status plugin type.
    *
-   * @var \Drupal\plugin\PluginTypeInterface
+   * @var \Drupal\plugin\PluginType\PluginTypeInterface
    */
   protected $paymentStatusType;
 

--- a/tests/src/Unit/Plugin/Payment/Status/PaymentStatusManagerTest.php
+++ b/tests/src/Unit/Plugin/Payment/Status/PaymentStatusManagerTest.php
@@ -12,7 +12,7 @@ use Drupal\Component\Plugin\Factory\FactoryInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\DependencyInjection\ClassResolverInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\StringTranslation\TranslationWrapper;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\payment\Plugin\Payment\Status\DefaultPaymentStatus;
 use Drupal\payment\Plugin\Payment\Status\PaymentStatusManager;
 use Drupal\Tests\UnitTestCase;
@@ -133,7 +133,7 @@ class PaymentStatusManagerTest extends UnitTestCase {
       ),
     );
     $manager_definitions = $discovery_definitions;
-    $manager_definitions['foo']['label'] = (new TranslationWrapper($manager_definitions['foo']['label']))->setStringTranslation($this->stringTranslation);
+    $manager_definitions['foo']['label'] = new TranslatableMarkup($manager_definitions['foo']['label'], [], [], $this->stringTranslation);
     $this->discovery->expects($this->once())
       ->method('getDefinitions')
       ->willReturn($discovery_definitions);


### PR DESCRIPTION
With this, at least the fatal error is gone, so the results can be fully shown and parsed again, by http://d8status.md-systems.ch/ for example.
