### PR TITLE
Use Plugin's PluginCollectionItemBase for the PaymentForm field type.

### DIFF
--- a/modules/payment_form/config/schema/payment_form.schema.yml
+++ b/modules/payment_form/config/schema/payment_form.schema.yml
@@ -45,12 +45,4 @@ field.field_settings.payment_form:
       label: The currency code
 
 field.value.payment_form:
-  type: config_object
-  label: Payment form field value
-  mapping:
-    plugin_id:
-      label: Plugin ID
-      type: string
-    plugin_configuration:
-      label: Plugin configuration
-      type: plugin.plugin_configuration.line_item.[%parent.plugin_id]
+  type: field.value.plugin:payment_line_item

--- a/modules/payment_form/src/Plugin/Field/FieldType/PaymentForm.php
+++ b/modules/payment_form/src/Plugin/Field/FieldType/PaymentForm.php
@@ -6,12 +6,9 @@
 
 namespace Drupal\payment_form\Plugin\Field\FieldType;
 
-use Drupal\Core\DependencyInjection\DependencySerializationTrait;
-use Drupal\Core\Field\FieldItemBase;
-use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\TypedData\DataDefinition;
 use Drupal\currency\Entity\Currency;
+use Drupal\payment\Plugin\Field\FieldType\PaymentAwarePluginCollectionItem;
 
 /**
  * Defines a payment form field.
@@ -20,12 +17,11 @@ use Drupal\currency\Entity\Currency;
  *   default_widget = "payment_form",
  *   default_formatter = "payment_form",
  *   id = "payment_form",
- *   label = @Translation("Payment form")
+ *   label = @Translation("Payment form"),
+ *   plugin_type_id = "payment_line_item"
  * )
  */
-class PaymentForm extends FieldItemBase {
-
-  use DependencySerializationTrait;
+class PaymentForm extends PaymentAwarePluginCollectionItem {
 
   /**
    * Definitions of the contained properties.
@@ -63,50 +59,4 @@ class PaymentForm extends FieldItemBase {
     return $element;
   }
 
-  /**
-   * {@inheritdoc}
-   */
-  public static function schema(FieldStorageDefinitionInterface $field_storage_definition) {
-    $schema = [
-      'columns' => [
-        'plugin_configuration' => [
-          'type' => 'blob',
-          'serialize' => TRUE,
-        ],
-        'plugin_id' => [
-          'type' => 'varchar',
-          'length' => 255,
-        ],
-      ],
-    ];
-
-    return $schema;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_storage_definition) {
-    // @todo Find out how to test this method, as it cannot use t() or
-    //   self::t().
-    $definitions = [];
-    $definitions['plugin_configuration'] = DataDefinition::create('any')
-      ->setLabel(t('Plugin configuration'))
-      ->setRequired(TRUE);
-    $definitions['plugin_id'] = DataDefinition::create('string')
-      ->setLabel(t('Plugin ID'))
-      ->setRequired(TRUE);
-
-    return $definitions;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function applyDefaultValue($notify = TRUE) {
-    $this->get('plugin_id')->setValue('', $notify);
-    $this->get('plugin_configuration')->setValue([], $notify);
-
-    return $this;
-  }
 }

--- a/src/Plugin/Field/FieldType/PaymentAwarePluginCollectionItem.php
+++ b/src/Plugin/Field/FieldType/PaymentAwarePluginCollectionItem.php
@@ -22,7 +22,8 @@ class PaymentAwarePluginCollectionItem extends PluginCollectionItem {
   public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition) {
     $properties = parent::propertyDefinitions($field_definition);
     $properties['plugin_instance'] = MapDataDefinition::create('payment_aware_plugin_instance')
-      ->setLabel(t('Plugin instance'));
+      ->setLabel(t('Plugin instance'))
+      ->setComputed(TRUE);
 
     return $properties;
   }


### PR DESCRIPTION
This improved the field type's DX by making it provide an actual API, as it now implements `\Drupal\plugin\Plugin\Field\FieldType\PluginCollectionItemInterface`. The removed code is replaced by what the Plugin module already provides.
