### PR TITLE
Fix errors related to TypedConfigManagerInterface

### DIFF
--- a/src/Entity/Payment/PaymentStatusForm.php
+++ b/src/Entity/Payment/PaymentStatusForm.php
@@ -121,7 +121,7 @@ class PaymentStatusForm extends EntityForm {
       /** @var \Drupal\payment\Entity\PaymentInterface $payment */
       $payment = $this->getEntity();
 
-      $plugin_type = $this->pluginTypeManager->getPluginType('payment_method');
+      $plugin_type = $this->pluginTypeManager->getPluginType('payment_status');
 
       $payment_method = $payment->getPaymentMethod();
       $payment_status_discovery = new LimitedPluginDiscoveryDecorator($plugin_type->getPluginManager());

--- a/tests/src/Unit/Entity/Payment/PaymentStatusFormTest.php
+++ b/tests/src/Unit/Entity/Payment/PaymentStatusFormTest.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\Tests\payment\Unit\Entity\Payment;
 
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\DependencyInjection\ClassResolverInterface;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Form\FormStateInterface;
@@ -77,6 +78,13 @@ class PaymentStatusFormTest extends UnitTestCase {
   protected $pluginTypeManager;
 
   /**
+   * The typed config manager
+   *
+   * @var \Drupal\Core\Config\TypedConfigManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+   */
+  protected $typedConfigManager;
+
+  /**
    * The string translator.
    *
    * @var \Drupal\Core\StringTranslation\TranslationInterface|\PHPUnit_Framework_MockObject_MockObject
@@ -114,12 +122,21 @@ class PaymentStatusFormTest extends UnitTestCase {
     $class_resolver = $this->getMock(ClassResolverInterface::class);
 
     $this->pluginTypeManager = $this->getmock(PluginTypeManagerInterface::class);
+
     $plugin_type_definition = [
       'id' => $this->randomMachineName(),
       'label' => $this->randomMachineName(),
       'provider' => $this->randomMachineName(),
     ];
-    $plugin_type = new PluginType($plugin_type_definition, $this->stringTranslation, $class_resolver, $this->paymentStatusManager);
+
+    $this->typedConfigManager = $this->getMock(TypedConfigManagerInterface::class);
+
+    $this->typedConfigManager->expects($this->once())
+      ->method('hasConfigSchema')
+      ->willReturn(true);
+
+    $plugin_type = new PluginType($plugin_type_definition, $this->stringTranslation, $class_resolver, $this->paymentStatusManager, $this->typedConfigManager);
+
     $this->pluginTypeManager->expects($this->any())
       ->method('getPluginType')
       ->with('payment_method')

--- a/tests/src/Unit/Entity/Payment/PaymentStatusFormTest.php
+++ b/tests/src/Unit/Entity/Payment/PaymentStatusFormTest.php
@@ -139,7 +139,7 @@ class PaymentStatusFormTest extends UnitTestCase {
 
     $this->pluginTypeManager->expects($this->any())
       ->method('getPluginType')
-      ->with('payment_method')
+      ->with('payment_status')
       ->willReturn($plugin_type);
 
     $this->urlGenerator = $this->getmock(UrlGeneratorInterface::class);


### PR DESCRIPTION
I have started to look into payment and saw that many tests fail because of a new argument in `PluginType` constructor:

```
Argument 5 passed to Drupal\plugin\PluginType\PluginType::__construct() 
must implement interface Drupal\Core\Config\TypedConfigManagerInterface, 
none given
```

I have made the test pass in `PaymentStatusFormTest` by mocking the new dependecy and a call to `hasConfigSchema`, however I am not familiar with the plugin module so I wanted to check if this is the right approach.
