### PR TITLE
PaymentReference::preSave() assumes $unchanged_entity doesn't exist; fatal errors with "call to a member function get() on null" if $unchanged_entity exists and payment reference field is empty

### DIFF
--- a/modules/payment_reference/src/Plugin/Field/FieldType/PaymentReference.php
+++ b/modules/payment_reference/src/Plugin/Field/FieldType/PaymentReference.php
@@ -146,7 +146,10 @@ class PaymentReference extends EntityReferenceItem {
       /** @var \Drupal\Core\Entity\ContentEntityInterface $unchanged_entity */
       $unchanged_entity = $entity_storage->loadUnchanged($current_entity->id());
       if ($unchanged_entity) {
-        $unchanged_payment_id = $unchanged_entity->get($this->getFieldDefinition()->getName())->get($this->name)->get('target_id')->getValue();
+        $unchanged_field = $unchanged_entity->get($this->getFieldDefinition()->getName());
+        if (!$unchanged_field->isEmpty()) {
+          $unchanged_payment_id = $unchanged_field->get($this->name)->get('target_id')->getValue();
+        }
       }
     }
     $current_payment_id = $this->get('target_id')->getValue();


### PR DESCRIPTION
Please see the issue summary at https://www.drupal.org/node/2913558