### PR TITLE
\Drupal\payment\Element\PaymentLineItemsDisplay::preRender() assumes payment reference field is not empty; fatal errors with "call to a member function formatAmount() on null" if it is

### DIFF
--- a/src/Element/PaymentLineItemsDisplay.php
+++ b/src/Element/PaymentLineItemsDisplay.php
@@ -126,24 +126,26 @@ class PaymentLineItemsDisplay extends FormElement implements ContainerFactoryPlu
 
     /** @var \Drupal\currency\Entity\CurrencyInterface $payment_line_items_currency */
     $payment_line_items_currency = $this->currencyStorage->load($payment_line_items->getCurrencyCode());
-    $element['table']['payment_total'] = array(
-      '#attributes' => array(
-        'class' => array('payment-amount'),
-      ),
-      'label' => array(
+    if ($payment_line_items_currency) {
+      $element['table']['payment_total'] = array(
         '#attributes' => array(
-          'class' => array('payment-amount-label'),
-          'colspan' => 3,
+          'class' => array('payment-amount'),
         ),
-        '#markup' => $this->t('Total amount'),
-      ),
-      'total' => array(
-        '#attributes' => array(
-          'class' => array('payment-amount-total'),
+        'label' => array(
+          '#attributes' => array(
+            'class' => array('payment-amount-label'),
+            'colspan' => 3,
+          ),
+          '#markup' => $this->t('Total amount'),
         ),
-        '#markup' => $payment_line_items_currency->formatAmount($payment_line_items->getAmount()),
-      ),
-    );
+        'total' => array(
+          '#attributes' => array(
+            'class' => array('payment-amount-total'),
+          ),
+          '#markup' => $payment_line_items_currency->formatAmount($payment_line_items->getAmount()),
+        ),
+      );
+    }
 
     return $element;
   }


### PR DESCRIPTION
Please see the issue summary at https://www.drupal.org/node/2913627